### PR TITLE
Add Cloud Shell quickstart one-liner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,6 @@ A single Bash script you can run inside cloud shells (AWS CloudShell, Azure Clou
 
 The script is read-only: it calls IAM “introspection” APIs (AWS simulate-principal-policy, Azure role/assignment reads, GCP testIamPermissions) and prints what’s missing so you can fix it before onboarding.
 
-## Setup
-
-Place the script file (preflight_check.sh) in your cloud shell home directory and make it executable:
-```bash
-chmod +x preflight_check.sh
-```
-
-### Quickstart (Cloud Shell one-liner)
-Use this in AWS CloudShell, Azure Cloud Shell, or Google Cloud Shell to download and run the latest script. It fetches `preflight_check.sh` from the main branch, makes it executable, and starts the menu.
-
-```bash
-curl -fsSLo preflight_check.sh https://raw.githubusercontent.com/PaloAltoNetworks/cc-permissions-preflight/main/preflight_check.sh && chmod +x preflight_check.sh && ./preflight_check.sh
-```
-
 ## Prerequisites
 
 Run the script from the matching cloud shell. If you run it locally, install and auth the CLIs first.
@@ -36,6 +22,20 @@ Run the script from the matching cloud shell. If you run it locally, install and
 ### GCP
 - Set project for project checks: gcloud config set project <PROJECT_ID>
 - For org checks, know your numeric Organization ID (e.g., 123456789012)
+
+## Quickstart (Cloud Shell one-liner)
+Use this in AWS CloudShell, Azure Cloud Shell, or Google Cloud Shell to download and run the latest script. It fetches `preflight_check.sh` from the main branch, makes it executable, and starts the menu.
+
+```bash
+curl -fsSLo preflight_check.sh https://raw.githubusercontent.com/PaloAltoNetworks/cc-permissions-preflight/main/preflight_check.sh && chmod +x preflight_check.sh && ./preflight_check.sh
+```
+
+## Setup
+
+Place the script file (preflight_check.sh) in your cloud shell home directory and make it executable:
+```bash
+chmod +x preflight_check.sh
+```
 
 ## Usage
 ```bash


### PR DESCRIPTION
## Description

- Add a “Quickstart (Cloud Shell one-liner)” section to the README directly after the Setup block.
- Includes a short preamble and a single command to download the latest `preflight_check.sh` from `main`, mark it executable, and run it:

  ```bash
  curl -fsSLo preflight_check.sh https://raw.githubusercontent.com/PaloAltoNetworks/cc-permissions-preflight/main/preflight_check.sh && chmod +x preflight_check.sh && ./preflight_check.sh
  ```

## Motivation and Context

- Makes first‑time usage simpler in AWS CloudShell, Azure Cloud Shell, and Google Cloud Shell.
- Reduces friction by removing manual download/placement steps.
- Documentation‑only change; no script behavior is modified.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

- Tested the one-liner in AWS and Azure Cloud Shells to confirm functionality

## Types of changes

- New feature (non-breaking change which adds ease-of-use functionality)


## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
