### PR TITLE
Fix(Azure): Correctly detect inherited roles and use ID for scope in tenant check

### DIFF
--- a/preflight_check.sh
+++ b/preflight_check.sh
@@ -1000,7 +1000,8 @@ azure_tenant_check() {
         local UAA_JSON
         UAA_JSON="$(az role assignment list \
             --assignee-object-id "$OBJECT_ID" \
-            --scope "/providers/Microsoft.Management/managementGroups/$ROOTMG" \
+            --scope "/providers/Microsoft.Management/managementGroups/$TENANT_ID" \
+            --include-inherited \
             --query "[?roleDefinitionName=='User Access Administrator']" \
             -o json 2>/dev/null || true)"
 
@@ -1022,7 +1023,8 @@ azure_tenant_check() {
             local TENANT_ROLES_JSON
             TENANT_ROLES_JSON="$(az role assignment list \
                 --assignee-object-id "$OBJECT_ID" \
-                --scope "/" \
+                --scope "/providers/Microsoft.Management/managementGroups/$TENANT_ID" \
+                --include-inherited \
                 --query "[?roleDefinitionName=='Owner' || roleDefinitionName=='Contributor']" \
                 -o json 2>/dev/null || true)"
 


### PR DESCRIPTION
Title: Fix(Azure): Correctly detect inherited roles and use ID for scope in tenant check
Description
This pull request addresses two issues in the azure_tenant_check() function to ensure accurate RBAC permission validation at the tenant root level:

Use Management Group ID for Scope: The command to list role assignments now correctly retrieves and uses the unique ID of the root management group for the --scope parameter, instead of its display name. This ensures the check reliably targets the correct resource as required by the Azure API.
Include Inherited Roles: The --include-inherited flag has been added to the az role assignment list command. This is crucial for detecting roles like User Access Administrator, which are often not assigned directly to the root management group but are inherited from the tenant root (/) when a Global Admin elevates their access.
Motivation and Context
The azure_tenant_check function was producing false negatives for users who had the necessary permissions. This was caused by two bugs:

The script failed to detect roles inherited from the tenant root scope.
The script was using the management group's display name instead of its unique ID, leading to an incorrect scope query.
These changes ensure the preflight check is accurate and reflects the user's true permissions as seen in the Azure Portal, preventing confusion and failed onboarding attempts.

How Has This Been Tested?
The updated script was validated on an Azure tenant where the user principal had the required permissions (Owner and User Access Administrator) at the root scope.

Before: The script failed to detect the inherited User Access Administrator role.
After: The script now correctly identifies both directly assigned and inherited roles, resulting in a successful permissions check.
Types of changes
 Bug fix (non-breaking change which fixes an issue)
