### PR TITLE
Add resource group migration permissions

### DIFF
--- a/preflight_check.sh
+++ b/preflight_check.sh
@@ -280,11 +280,14 @@ PERMISSIONS_AZURE_MG_BASE=(
     "Microsoft.ManagedIdentity/userAssignedIdentities/assign/action"
     "Microsoft.Management/managementGroups/descendants/read"
     "Microsoft.Management/managementGroups/subscriptions/read"
-)
-PERMISSIONS_AZURE_MG_AUDIT_LOGS=(
     "Microsoft.Resources/subscriptions/resourcegroups/read"
     "Microsoft.Resources/subscriptions/resourcegroups/write"
     "Microsoft.Resources/subscriptions/resourceGroups/delete"
+    "Microsoft.Resources/subscriptions/resourceGroups/moveResources/action"
+    "Microsoft.Resources/subscriptions/resourceGroups/validateMoveResources/action"
+    
+)
+PERMISSIONS_AZURE_MG_AUDIT_LOGS=(
     "Microsoft.Resources/deploymentScripts/write"
     "Microsoft.Resources/deploymentScripts/read"
     "Microsoft.Resources/deploymentScripts/delete"


### PR DESCRIPTION
## Description

Added the following permissions to Azure:
- `Microsoft.Resources/subscriptions/resourceGroups/validateMoveResources/action`
- `Microsoft.Resources/subscriptions/resourceGroups/moveResources/action`

## Motivation and Context

Previously, users were required to create their own resource group for Azure onboarding and then to provide the name of the resource group to the onboarding script. Today, we are creating our own resource group meaning any user who onboarded before this change will need to migrate their onboarded resources to the new resource group. The migration is done via the ["move resources"](https://learn.microsoft.com/en-us/cli/azure/resource?view=azure-cli-latest#az-resource-move) command. There are specific permissions for moving and for validation of the resource that are relocated. 

These permissions [already exist in the official docs
](https://docs-cortex.paloaltonetworks.com/r/Cortex-CLOUD/Cortex-Cloud-Runtime-Security-Documentation/Onboard-Microsoft-Azure?tocId=MvDGGRtwdZjW_k8SU7L6yg&section=UUID-70717097-1a31-3bfa-30df-07dbf570f8d6_section-idm235098922904156).
## Types of changes

- New feature (non-breaking change which adds functionality)
