### PR TITLE
Add move resources permissions validation

### DIFF
--- a/preflight_check.sh
+++ b/preflight_check.sh
@@ -280,6 +280,8 @@ PERMISSIONS_AZURE_MG_AUDIT_LOGS=(
     "Microsoft.Resources/subscriptions/resourcegroups/read"
     "Microsoft.Resources/subscriptions/resourcegroups/write"
     "Microsoft.Resources/subscriptions/resourceGroups/delete"
+    "Microsoft.Resources/subscriptions/resourceGroups/moveResources/action"
+    "Microsoft.Resources/subscriptions/resourceGroups/validateMoveResources/action"
     "Microsoft.Resources/deploymentScripts/write"
     "Microsoft.Resources/deploymentScripts/read"
     "Microsoft.Resources/deploymentScripts/delete"
@@ -628,6 +630,14 @@ azure_subscription_check() {
 
     echo "Using subscription: $CURRENT_SUBSCRIPTION"
     echo
+        
+    az account set --subscription "$CURRENT_SUBSCRIPTION" 2>/dev/null
+
+    if [ $? -ne 0 ]; then
+        echo "❌ ERROR: Failed to set Azure subscription context."
+        log_error "❌ Failed to set Azure subscription context: $CURRENT_SUBSCRIPTION"
+        exit 1
+    fi
 
     # this flag will be set to 'false' if any provider fails the check
     ALL_CHECKS_PASSED=true
@@ -652,7 +662,7 @@ azure_subscription_check() {
             ALL_CHECKS_PASSED=false
             FAILED_PROVIDERS+=("$provider (Status: Registering)")
             
-        elif [ "$STATE" == "NotRegistered" ]; then
+        elif [ "$STATE" == "NotRegistered" ] || [ "$STATE" == "Unregistered" ]; then
             echo -e "${RED}❌ Not Registered${NC}"
             echo -e "   ${YELLOW}-> SOLUTION:${NC} This provider is required. Run the following command:"
             echo -e "      ${BOLD}az provider register --namespace $provider --subscription $CURRENT_SUBSCRIPTION${NC}"
@@ -989,6 +999,14 @@ azure_management_group_check() {
 
     echo "Using subscription: $CURRENT_SUBSCRIPTION"
     echo
+        
+    az account set --subscription "$CURRENT_SUBSCRIPTION" 2>/dev/null
+
+    if [ $? -ne 0 ]; then
+        echo "❌ ERROR: Failed to set Azure subscription context."
+        log_error "❌ Failed to set Azure subscription context: $CURRENT_SUBSCRIPTION"
+        exit 1
+    fi
 
     # this flag will be set to 'false' if any provider fails the check
     ALL_CHECKS_PASSED=true
@@ -1013,7 +1031,7 @@ azure_management_group_check() {
             ALL_CHECKS_PASSED=false
             FAILED_PROVIDERS+=("$provider (Status: Registering)")
             
-        elif [ "$STATE" == "NotRegistered" ]; then
+        elif [ "$STATE" == "NotRegistered" ] || [ "$STATE" == "Unregistered" ]; then
             echo -e "${RED}❌ Not Registered${NC}"
             echo -e "   ${YELLOW}-> SOLUTION:${NC} This provider is required. Run the following command:"
             echo -e "      ${BOLD}az provider register --namespace $provider --subscription $CURRENT_SUBSCRIPTION${NC}"
@@ -1427,6 +1445,14 @@ azure_tenant_check() {
     echo "Using subscription: $CURRENT_SUBSCRIPTION"
     echo
 
+    az account set --subscription "$CURRENT_SUBSCRIPTION" 2>/dev/null
+
+    if [ $? -ne 0 ]; then
+        echo "❌ ERROR: Failed to set Azure subscription context."
+        log_error "❌ Failed to set Azure subscription context: $CURRENT_SUBSCRIPTION"
+        exit 1
+    fi
+
     # this flag will be set to 'false' if any provider fails the check
     ALL_CHECKS_PASSED=true
 
@@ -1450,7 +1476,7 @@ azure_tenant_check() {
             ALL_CHECKS_PASSED=false
             FAILED_PROVIDERS+=("$provider (Status: Registering)")
             
-        elif [ "$STATE" == "NotRegistered" ]; then
+        elif [ "$STATE" == "NotRegistered" ] || [ "$STATE" == "Unregistered" ]; then
             echo -e "${RED}❌ Not Registered${NC}"
             echo -e "   ${YELLOW}-> SOLUTION:${NC} This provider is required. Run the following command:"
             echo -e "      ${BOLD}az provider register --namespace $provider --subscription $CURRENT_SUBSCRIPTION${NC}"


### PR DESCRIPTION
Description
This PR introduces two related improvements to the Azure onboarding workflow:

Adds required Azure permissions for resource group migration:
Microsoft.Resources/subscriptions/resourceGroups/validateMoveResources/action
Microsoft.Resources/subscriptions/resourceGroups/moveResources/action
Fixes Azure CLI subscription context drift by explicitly setting and enforcing the active subscription during validation and onboarding.
Motivation and Context
Resource Group Migration
Previously, users were required to create their own resource group for Azure onboarding and provide its name to the onboarding script. The workflow now creates its own resource group automatically. As a result, users who onboarded prior to this change must migrate their existing onboarded resources to the new resource group.

This migration uses the Azure CLI ["move resources"](https://learn.microsoft.com/en-us/cli/azure/resource?view=azure-cli-latest#az-resource-move) command, which requires specific permissions for both validation and execution. These permissions already exist in the official documentation:

https://docs-cortex.paloaltonetworks.com/r/Cortex-CLOUD/Cortex-Cloud-Runtime-Security-Documentation/Onboard-Microsoft-Azure?tocId=MvDGGRtwdZjW_k8SU7L6yg&section=UUID-70717097-1a31-3bfa-30df-07dbf570f8d6_section-idm235098922904156

They are now explicitly included to prevent onboarding and migration failures.

Azure Subscription Context Drift
We also identified an issue where provider validation was running against the Azure CLI default subscription, while the onboarding workflow could later switch subscriptions. This resulted in validation being performed against a different subscription than the actual deployment target.

Root Cause
Azure CLI context was implicit and could change during execution, leading to inconsistent behavior between pre-checks and onboarding.

Solution
Capture the active subscription once at startup.
Explicitly set the Azure CLI context using az account set.
Pass --subscription to all Azure CLI commands to ensure deterministic execution.

Example:

CURRENT_SUBSCRIPTION=$(az account show --query id -o tsv)
az account set --subscription "$CURRENT_SUBSCRIPTION"
az provider show --namespace Microsoft.Insights --subscription "$CURRENT_SUBSCRIPTION"